### PR TITLE
fix empty my_id on phone_number login

### DIFF
--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -1115,7 +1115,7 @@ class Client(Decorators, Methods):
 
             is_phone = user_input.startswith('+')
             input_type = "phone number" if is_phone else "bot token"
-            
+
             y_n = await self.__ainput(f'Is "{user_input}" your {input_type}? (y/n): ')
             if y_n.lower() not in {"y", "yes"}:
                 continue


### PR DESCRIPTION
If set phone to token my_id check prevent from  working.

`_set_bot_token` wasn't used. I renamed it to a better name `_auth_with_token`

improved login logic a bit. But I think is better to remove console input requests and provide the way to use it from outside as necessary.