### PR TITLE
refactor: cache type lookups and deduplicate dispatch

### DIFF
--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -192,12 +192,14 @@ class Client(Decorators, Methods):
         self.is_nats = True if nats_url else False
         self.options = {}
         self.allow_outgoing_message_types: tuple = (types.MessagePaymentRefunded,)
-        self.get_message_methods = {
-            "getmessage",
-            "getmessagelocally",
-            "getrepliedmessage",
-            "getcallbackquerymessage",
-        }  # TODO: improve this
+        self.get_message_methods = frozenset(
+            {
+                "getmessage",
+                "getmessagelocally",
+                "getrepliedmessage",
+                "getcallbackquerymessage",
+            }
+        )
 
         self._check_init_args()
 
@@ -785,14 +787,14 @@ class Client(Decorators, Methods):
                 continue
 
             plugin_handlers_count = 0
+            seen = set()
             handlers_to_load = []
-            handlers_to_load += [
-                obj._handler
-                for obj in vars(module).values()
-                if hasattr(obj, "_handler")
-                and isinstance(obj._handler, Handler)
-                and obj._handler not in handlers_to_load
-            ]
+            for obj in vars(module).values():
+                if hasattr(obj, "_handler") and isinstance(obj._handler, Handler):
+                    hid = id(obj._handler)
+                    if hid not in seen:
+                        seen.add(hid)
+                        handlers_to_load.append(obj._handler)
 
             for handler in handlers_to_load:
                 if iscoroutinefunction(handler.func):

--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -874,52 +874,16 @@ class Client(Decorators, Methods):
             return update.message
         return update
 
-    async def __run_initializers(self, update):
+    async def __run_handler_group(self, update, handlers, label):
         inner_object = self.get_inner_object(update)
 
-        for initializer in self._current_handlers["initializer"]:
-            try:
-                handler_value = inner_object if initializer.inner_object else update
-
-                if initializer.filter is not None:
-                    filter_function = initializer.filter.func
-
-                    if self.is_coro_filter(filter_function):
-                        if not await filter_function(self, handler_value):
-                            continue
-                    elif not filter_function(self, handler_value):
-                        continue
-
-                if (
-                    self.default_handlers_timeout is None
-                    and initializer.timeout is None
-                ):
-                    await initializer(self, handler_value)
-                else:
-                    timeout = initializer.timeout or self.default_handlers_timeout
-                    try:
-                        await asyncio.wait_for(
-                            initializer(self, handler_value),
-                            timeout=timeout,
-                        )
-                    except asyncio.TimeoutError:
-                        self.logger.warning(
-                            f"Initializer {initializer} timed out after {timeout} seconds"
-                        )
-            except StopHandlers as e:
-                raise e
-            except Exception:
-                self.logger.exception(f"Initializer {initializer} failed")
-
-    async def __run_handlers(self, update):
-        inner_object = self.get_inner_object(update)
-
-        for handler in self._current_handlers[update.getType()]:
+        for handler in handlers:
             try:
                 handler_value = inner_object if handler.inner_object else update
 
                 if handler.filter is not None:
                     filter_function = handler.filter.func
+
                     if self.is_coro_filter(filter_function):
                         if not await filter_function(self, handler_value):
                             continue
@@ -932,50 +896,32 @@ class Client(Decorators, Methods):
                     timeout = handler.timeout or self.default_handlers_timeout
                     try:
                         await asyncio.wait_for(
-                            handler(self, handler_value), timeout=timeout
-                        )
-                    except asyncio.TimeoutError:
-                        self.logger.warning(
-                            f"Handler {handler} timed out after {timeout} seconds"
-                        )
-            except StopHandlers as e:
-                raise e
-            except Exception:
-                self.logger.exception(f"Exception in {handler}")
-
-    async def __run_finalizers(self, update):
-        inner_object = self.get_inner_object(update)
-
-        for finalizer in self._current_handlers["finalizer"]:
-            try:
-                handler_value = inner_object if finalizer.inner_object else update
-
-                if finalizer.filter is not None:
-                    filter_function = finalizer.filter.func
-
-                    if self.is_coro_filter(filter_function):
-                        if not await filter_function(self, handler_value):
-                            continue
-                    elif not filter_function(self, handler_value):
-                        continue
-
-                if self.default_handlers_timeout is None and finalizer.timeout is None:
-                    await finalizer(self, handler_value)
-                else:
-                    try:
-                        timeout = finalizer.timeout or self.default_handlers_timeout
-                        await asyncio.wait_for(
-                            finalizer(self, handler_value),
+                            handler(self, handler_value),
                             timeout=timeout,
                         )
                     except asyncio.TimeoutError:
                         self.logger.warning(
-                            f"Finalizer {finalizer} timed out after {timeout} seconds"
+                            f"{label} {handler} timed out after {timeout} seconds"
                         )
             except StopHandlers as e:
                 raise e
             except Exception:
-                self.logger.exception(f"Finalizer {finalizer} failed")
+                self.logger.exception(f"{label} {handler} failed")
+
+    async def __run_initializers(self, update):
+        await self.__run_handler_group(
+            update, self._current_handlers["initializer"], "Initializer"
+        )
+
+    async def __run_handlers(self, update):
+        await self.__run_handler_group(
+            update, self._current_handlers[update.getType()], "Handler"
+        )
+
+    async def __run_finalizers(self, update):
+        await self.__run_handler_group(
+            update, self._current_handlers["finalizer"], "Finalizer"
+        )
 
     async def _handle_update(self, update):
         if update.getType() in self._current_handlers:

--- a/pytdbot/utils/escape.py
+++ b/pytdbot/utils/escape.py
@@ -21,6 +21,9 @@ def escape_html(text: str, quote: bool = True) -> str:
 special_chars_v1 = r"_\*`\["
 special_chars_v2 = r"\_*[]()~`>#+-=|{}.!"
 
+_special_chars_v1_set = set(special_chars_v1)
+_special_chars_v2_set = set(special_chars_v2)
+
 
 def escape_markdown(text: str, version: int = 2) -> str:
     r"""Escape Markdown characters in the given text
@@ -40,9 +43,9 @@ def escape_markdown(text: str, version: int = 2) -> str:
     """
 
     if version == 1:
-        chars = special_chars_v1
+        chars = _special_chars_v1_set
     elif version == 2:
-        chars = special_chars_v2
+        chars = _special_chars_v2_set
     else:
         raise ValueError("Invalid version. Must be 1 or 2.")
 

--- a/pytdbot/utils/obj_encoder.py
+++ b/pytdbot/utils/obj_encoder.py
@@ -3,6 +3,8 @@ from base64 import b64encode
 
 from .. import types, utils
 
+_type_cache = {}
+
 
 def obj_to_json(obj, **kwargs):
     return json.dumps(obj_to_dict(obj), **kwargs)
@@ -24,7 +26,13 @@ def obj_to_dict(obj):
 def dict_to_obj(dict_obj, client=None):
     if isinstance(dict_obj, dict):
         if "@type" in dict_obj:
-            obj = getattr(types, utils.to_camel_case(dict_obj["@type"])).from_dict(
+            td_type = dict_obj["@type"]
+            obj_type = _type_cache.get(td_type)
+            if obj_type is None:
+                obj_type = getattr(types, utils.to_camel_case(td_type))
+                _type_cache[td_type] = obj_type
+
+            obj = obj_type.from_dict(
                 {key: dict_to_obj(value, client) for key, value in dict_obj.items()}
             )
             if client:

--- a/pytdbot/utils/strings.py
+++ b/pytdbot/utils/strings.py
@@ -9,20 +9,20 @@ def to_camel_case(input_str: str, delimiter: str = ".", is_class: bool = True) -
         return ""
 
     parts = input_str.split(delimiter)
-    camel_case_str = ""
 
-    for i, part in enumerate(parts):
-        if i > 0:
-            camel_case_str += part[0].upper() + part[1:]
-        else:
-            camel_case_str += part
+    result = [parts[0]]
+    for part in parts[1:]:
+        result.append(part[0].upper())
+        result.append(part[1:])
 
-    if camel_case_str:
-        camel_case_str = (
-            camel_case_str[0].upper() if is_class else camel_case_str[0].lower()
-        ) + camel_case_str[1:]
+    joined = "".join(result)
 
-    return camel_case_str
+    if not joined:
+        return ""
+
+    if is_class:
+        return joined[0].upper() + joined[1:]
+    return joined[0].lower() + joined[1:]
 
 
 def create_extra_id(bytes_size: int = 9):


### PR DESCRIPTION
## Summary
- cache repeated type lookups used in hot paths
- deduplicate handler dispatch work
- keep behavior scoped to existing dispatch flow

## Validation
- `git diff --check fork/main..perf/cache-and-dispatch`
- branch tip verified with `git verify-commit`
