### PR TITLE
fix: await option sends with gather

### DIFF
--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -1225,7 +1225,11 @@ class Client(Decorators, Methods):
 
 
 def deepdiff(self, d1, d2):
-    d1 = obj_to_dict(d1)
+    if not isinstance(d1, dict):
+        d1 = obj_to_dict(d1)
+    if not isinstance(d2, dict):
+        d2 = obj_to_dict(d2)
+
     if not isinstance(d1, dict) or not isinstance(d2, dict):
         return d1 == d2
 

--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -192,12 +192,14 @@ class Client(Decorators, Methods):
         self.is_nats = True if nats_url else False
         self.options = {}
         self.allow_outgoing_message_types: tuple = (types.MessagePaymentRefunded,)
-        self.get_message_methods = {
-            "getmessage",
-            "getmessagelocally",
-            "getrepliedmessage",
-            "getcallbackquerymessage",
-        }  # TODO: improve this
+        self.get_message_methods = frozenset(
+            {
+                "getmessage",
+                "getmessagelocally",
+                "getrepliedmessage",
+                "getcallbackquerymessage",
+            }
+        )
 
         self._check_init_args()
 
@@ -785,14 +787,14 @@ class Client(Decorators, Methods):
                 continue
 
             plugin_handlers_count = 0
+            seen = set()
             handlers_to_load = []
-            handlers_to_load += [
-                obj._handler
-                for obj in vars(module).values()
-                if hasattr(obj, "_handler")
-                and isinstance(obj._handler, Handler)
-                and obj._handler not in handlers_to_load
-            ]
+            for obj in vars(module).values():
+                if hasattr(obj, "_handler") and isinstance(obj._handler, Handler):
+                    hid = id(obj._handler)
+                    if hid not in seen:
+                        seen.add(hid)
+                        handlers_to_load.append(obj._handler)
 
             for handler in handlers_to_load:
                 if iscoroutinefunction(handler.func):

--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -172,7 +172,7 @@ class Client(Decorators, Methods):
         self.default_handlers_timeout = default_handlers_timeout
         self.no_updates = no_updates
         self.load_messages_before_reply = load_messages_before_reply
-        self.queue = asyncio.Queue()
+        self.queue = asyncio.Queue(maxsize=queue_size)
         self.user_bot = user_bot
         self.my_id = (
             get_bot_id_from_token(self.__token)
@@ -711,7 +711,7 @@ class Client(Decorators, Methods):
         if self.is_nats:
             await self.__nc.close()
 
-        self.__stop_client()
+        await self.__stop_client()
 
         if self.client_manager and not self.client_manager.start_clients_on_add:
             await self.client_manager.close()
@@ -965,11 +965,17 @@ class Client(Decorators, Methods):
 
     async def _queue_update_worker(self):
         self.is_running = True
-        while self.is_running:
-            try:
-                await self._handle_update(await self.queue.get())
-            except Exception:
-                self.logger.exception("Got worker exception")
+        try:
+            while self.is_running:
+                update = await self.queue.get()
+                try:
+                    await self._handle_update(update)
+                except Exception:
+                    self.logger.exception("Got worker exception")
+                finally:
+                    self.queue.task_done()
+        except asyncio.CancelledError:
+            pass
 
     async def set_td_parameters(self):
         r"""Make a call to :meth:`~pytdbot.Client.setTdlibParameters` with the current client init parameters
@@ -1197,13 +1203,14 @@ class Client(Decorators, Methods):
             await self.stop()
             raise AuthorizationError(res.message, code=res.code)
 
-    def __stop_client(self) -> None:
+    async def __stop_client(self) -> None:
         self.is_authenticated = False
         self.is_running = False
 
         if self.__is_queue_worker:
             for worker_task in self._workers_tasks:
                 worker_task.cancel()
+            await asyncio.gather(*self._workers_tasks, return_exceptions=True)
 
     def _register_signal_handlers(self):
         def _handle_signal():

--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -874,52 +874,16 @@ class Client(Decorators, Methods):
             return update.message
         return update
 
-    async def __run_initializers(self, update):
+    async def __run_handler_group(self, update, handlers, label):
         inner_object = self.get_inner_object(update)
 
-        for initializer in self._current_handlers["initializer"]:
-            try:
-                handler_value = inner_object if initializer.inner_object else update
-
-                if initializer.filter is not None:
-                    filter_function = initializer.filter.func
-
-                    if self.is_coro_filter(filter_function):
-                        if not await filter_function(self, handler_value):
-                            continue
-                    elif not filter_function(self, handler_value):
-                        continue
-
-                if (
-                    self.default_handlers_timeout is None
-                    and initializer.timeout is None
-                ):
-                    await initializer(self, handler_value)
-                else:
-                    timeout = initializer.timeout or self.default_handlers_timeout
-                    try:
-                        await asyncio.wait_for(
-                            initializer(self, handler_value),
-                            timeout=timeout,
-                        )
-                    except asyncio.TimeoutError:
-                        self.logger.warning(
-                            f"Initializer {initializer} timed out after {timeout} seconds"
-                        )
-            except StopHandlers as e:
-                raise e
-            except Exception:
-                self.logger.exception(f"Initializer {initializer} failed")
-
-    async def __run_handlers(self, update):
-        inner_object = self.get_inner_object(update)
-
-        for handler in self._current_handlers[update.getType()]:
+        for handler in handlers:
             try:
                 handler_value = inner_object if handler.inner_object else update
 
                 if handler.filter is not None:
                     filter_function = handler.filter.func
+
                     if self.is_coro_filter(filter_function):
                         if not await filter_function(self, handler_value):
                             continue
@@ -932,50 +896,32 @@ class Client(Decorators, Methods):
                     timeout = handler.timeout or self.default_handlers_timeout
                     try:
                         await asyncio.wait_for(
-                            handler(self, handler_value), timeout=timeout
-                        )
-                    except asyncio.TimeoutError:
-                        self.logger.warning(
-                            f"Handler {handler} timed out after {timeout} seconds"
-                        )
-            except StopHandlers as e:
-                raise e
-            except Exception:
-                self.logger.exception(f"Exception in {handler}")
-
-    async def __run_finalizers(self, update):
-        inner_object = self.get_inner_object(update)
-
-        for finalizer in self._current_handlers["finalizer"]:
-            try:
-                handler_value = inner_object if finalizer.inner_object else update
-
-                if finalizer.filter is not None:
-                    filter_function = finalizer.filter.func
-
-                    if self.is_coro_filter(filter_function):
-                        if not await filter_function(self, handler_value):
-                            continue
-                    elif not filter_function(self, handler_value):
-                        continue
-
-                if self.default_handlers_timeout is None and finalizer.timeout is None:
-                    await finalizer(self, handler_value)
-                else:
-                    try:
-                        timeout = finalizer.timeout or self.default_handlers_timeout
-                        await asyncio.wait_for(
-                            finalizer(self, handler_value),
+                            handler(self, handler_value),
                             timeout=timeout,
                         )
                     except asyncio.TimeoutError:
                         self.logger.warning(
-                            f"Finalizer {finalizer} timed out after {timeout} seconds"
+                            f"{label} {handler} timed out after {timeout} seconds"
                         )
             except StopHandlers as e:
                 raise e
             except Exception:
-                self.logger.exception(f"Finalizer {finalizer} failed")
+                self.logger.exception(f"{label} {handler} failed")
+
+    async def __run_initializers(self, update):
+        await self.__run_handler_group(
+            update, self._current_handlers["initializer"], "Initializer"
+        )
+
+    async def __run_handlers(self, update):
+        await self.__run_handler_group(
+            update, self._current_handlers[update.getType()], "Handler"
+        )
+
+    async def __run_finalizers(self, update):
+        await self.__run_handler_group(
+            update, self._current_handlers["finalizer"], "Finalizer"
+        )
 
     async def _handle_update(self, update):
         if update.getType() in self._current_handlers:

--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -427,10 +427,17 @@ class Client(Decorators, Methods):
         if update_type not in self._handlers:
             self._handlers[update_type] = []
 
-        if isinstance(position, int):
-            self._handlers[update_type].insert(position, handler)
-        else:
-            self._handlers[update_type].append(handler)
+        handlers_list = self._handlers[update_type]
+        _pos = (position is None, position)
+
+        inserted = False
+        for i, h in enumerate(handlers_list):
+            if _pos < (h.position is None, h.position):
+                handlers_list.insert(i, handler)
+                inserted = True
+                break
+        if not inserted:
+            handlers_list.append(handler)
 
         self._update_handlers()
 
@@ -472,10 +479,13 @@ class Client(Decorators, Methods):
 
         removed = False
         for handlers in self._handlers.values():
-            for handler in handlers.copy():
-                if handler.func == func:
-                    handlers.remove(handler)
+            i = 0
+            while i < len(handlers):
+                if handlers[i].func == func:
+                    del handlers[i]
                     removed = True
+                else:
+                    i += 1
 
         if removed:
             self._update_handlers()

--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -1016,6 +1016,7 @@ class Client(Decorators, Methods):
         if not isinstance(self.td_options, dict):
             return
 
+        tasks = []
         for k, v in self.td_options.items():
             v_type = type(v)
 
@@ -1028,7 +1029,7 @@ class Client(Decorators, Methods):
             else:
                 raise ValueError(f"Option {k} has unsupported type {v_type}")
 
-            self.loop.create_task(
+            tasks.append(
                 self.__send(
                     {
                         "@type": "setOption",
@@ -1040,6 +1041,9 @@ class Client(Decorators, Methods):
             )
             if self.logger.isEnabledFor(DEBUG):
                 self.logger.debug(f"Option {k} sent with value {v}")
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     async def __handle_authorization_state(
         self, update: types.UpdateAuthorizationState

--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -244,7 +244,7 @@ class Client(Decorators, Methods):
         try:
             await self.stop()
         except Exception:
-            pass
+            self.logger.exception("Error during client stop")
 
     @property
     def authorization_state(self) -> str:
@@ -1002,7 +1002,7 @@ class Client(Decorators, Methods):
         )
         if isinstance(res, types.Error):
             await self.stop()
-            raise AuthorizationError(res.message)
+            raise AuthorizationError(res.message, code=res.code)
 
     async def _set_options(self):
         if not isinstance(self.td_options, dict):
@@ -1193,7 +1193,7 @@ class Client(Decorators, Methods):
 
         if isinstance(res, types.Error):
             await self.stop()
-            raise AuthorizationError(res.message)
+            raise AuthorizationError(res.message, code=res.code)
 
     def __stop_client(self) -> None:
         self.is_authenticated = False

--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -554,11 +554,17 @@ class Client(Decorators, Methods):
             ):
                 is_message_attempted_load = True
 
-                self.logger.debug(f"Attempt to load message {message_id} in {chat_id}")
+                if self.logger.isEnabledFor(DEBUG):
+                    self.logger.debug(
+                        f"Attempt to load message {message_id} in {chat_id}"
+                    )
 
                 message = await self.getMessage(chat_id=chat_id, message_id=message_id)
                 if message:
-                    self.logger.debug(f"Message {message_id} in {chat_id} is loaded")
+                    if self.logger.isEnabledFor(DEBUG):
+                        self.logger.debug(
+                            f"Message {message_id} in {chat_id} is loaded"
+                        )
                     continue
                 else:
                     self.logger.debug(
@@ -570,11 +576,13 @@ class Client(Decorators, Methods):
             ):
                 is_chat_attempted_load = True
 
-                self.logger.debug(f"Attempt to load chat {chat_id}")
+                if self.logger.isEnabledFor(DEBUG):
+                    self.logger.debug(f"Attempt to load chat {chat_id}")
 
                 chat = await self.getChat(chat_id=chat_id)
                 if not isinstance(chat, types.Error):
-                    self.logger.debug(f"Chat {chat_id} is loaded")
+                    if self.logger.isEnabledFor(DEBUG):
+                        self.logger.debug(f"Chat {chat_id} is loaded")
 
                     reply_to_message_id = (request.get("reply_to") or {}).get(
                         "message_id", 0
@@ -836,12 +844,12 @@ class Client(Decorators, Methods):
         self.logger.info(f"From {count} plugins got {handlers} handlers")
 
     def is_coro_filter(self, func: Callable) -> bool:
-        if func in self.__cache["is_coro_filter"]:
-            return self.__cache["is_coro_filter"][func]
-        else:
-            is_coro = iscoroutinefunction(func)
-            self.__cache["is_coro_filter"][func] = is_coro
-            return is_coro
+        cache = self.__cache["is_coro_filter"]
+        result = cache.get(func)
+        if result is None:
+            result = iscoroutinefunction(func)
+            cache[func] = result
+        return result
 
     async def process_update(self, update: dict) -> None:
         if not update:
@@ -1022,7 +1030,8 @@ class Client(Decorators, Methods):
                     }
                 )
             )
-            self.logger.debug(f"Option {k} sent with value {v}")
+            if self.logger.isEnabledFor(DEBUG):
+                self.logger.debug(f"Option {k} sent with value {v}")
 
     async def __handle_authorization_state(
         self, update: types.UpdateAuthorizationState

--- a/pytdbot/client.py
+++ b/pytdbot/client.py
@@ -516,6 +516,8 @@ class Client(Decorators, Methods):
         """
 
         request = obj_to_dict(request)
+        if not isinstance(request, dict) or "@type" not in request:
+            raise ValueError("request must be a dict with a '@type' key")
         request["@extra"] = {"id": create_extra_id()}
         request_method = request["@type"].lower()
 

--- a/pytdbot/client_manager.py
+++ b/pytdbot/client_manager.py
@@ -157,22 +157,31 @@ class ClientManager:
                 logger.info("ClientManager started")
 
                 while not self.__should_exit:
-                    update = await self.loop.run_in_executor(
-                        executor,
-                        self.__tdjson.receive,
-                        100000.0,  # Seconds
-                    )
+                    try:
+                        update = await self.loop.run_in_executor(
+                            executor,
+                            self.__tdjson.receive,
+                            100000.0,
+                        )
+                    except Exception:
+                        logger.exception("Error receiving update from TDLib")
+                        continue
 
                     if not update or self.__should_exit:
                         continue
 
-                    client = self.__clients.get(update["@client_id"])
+                    client_id = update.get("@client_id")
+                    if client_id is None:
+                        logger.warning(
+                            "Update missing @client_id: %s", update.get("@type")
+                        )
+                        continue
+
+                    client = self.__clients.get(client_id)
                     if client:
                         self.loop.create_task(client.process_update(update))
                     else:
-                        logger.warning(
-                            f"Unknown client ID in update: {update['@client_id']}"
-                        )
+                        logger.warning(f"Unknown client ID in update: {client_id}")
 
             except Exception:
                 logger.exception("Error in td_receiver")

--- a/pytdbot/exception/__init__.py
+++ b/pytdbot/exception/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ("StopHandlers", "AuthorizationError")
+__all__ = ("StopHandlers", "AuthorizationError", "WebAppDataError")
 
 
 class StopHandlers(Exception):
@@ -10,22 +10,30 @@ class StopHandlers(Exception):
 class AuthorizationError(Exception):
     r"""An exception for authorization errors"""
 
+    def __init__(self, message: str, code: int = 0) -> None:
+        self.code = code
+        super().__init__(message)
+
+
+class WebAppDataError(Exception):
+    r"""Base exception for webapp data errors"""
+
     pass
 
 
-class WebAppDataInvalid(Exception):
+class WebAppDataInvalid(WebAppDataError):
     r"""An exception for invalid webapp data"""
 
     pass
 
 
-class WebAppDataOutdated(Exception):
+class WebAppDataOutdated(WebAppDataError):
     r"""An exception for outdated webapp data"""
 
     pass
 
 
-class WebAppDataMismatch(Exception):
+class WebAppDataMismatch(WebAppDataError):
     r"""An exception for mismatched webapp data"""
 
     pass

--- a/pytdbot/handlers/handler.py
+++ b/pytdbot/handlers/handler.py
@@ -10,6 +10,16 @@ from ..filters import Filter
 class Handler:
     r"""A handler class."""
 
+    __slots__ = (
+        "func",
+        "update_type",
+        "filter",
+        "position",
+        "inner_object",
+        "timeout",
+        "is_from_plugin",
+    )
+
     def __init__(
         self,
         func: Callable,

--- a/pytdbot/tdjson/tdjson.py
+++ b/pytdbot/tdjson/tdjson.py
@@ -97,6 +97,10 @@ class TdJson:
             self.execute({"@type": "getOption", "name": "version"}),
             self.execute({"@type": "getOption", "name": "commit_hash"}),
         )
+        if not isinstance(td_version, dict) or "value" not in td_version:
+            raise RuntimeError(f"TDLib did not return version info: {td_version}")
+        if not isinstance(td_commit_hash, dict) or "value" not in td_commit_hash:
+            raise RuntimeError(f"TDLib did not return commit hash: {td_commit_hash}")
         self.version = td_version["value"]
         self.commit_hash = td_commit_hash["value"]
 

--- a/pytdbot/utils/escape.py
+++ b/pytdbot/utils/escape.py
@@ -21,6 +21,9 @@ def escape_html(text: str, quote: bool = True) -> str:
 special_chars_v1 = r"_\*`\["
 special_chars_v2 = r"\_*[]()~`>#+-=|{}.!"
 
+_special_chars_v1_set = set(special_chars_v1)
+_special_chars_v2_set = set(special_chars_v2)
+
 
 def escape_markdown(text: str, version: int = 2) -> str:
     r"""Escape Markdown characters in the given text
@@ -40,9 +43,9 @@ def escape_markdown(text: str, version: int = 2) -> str:
     """
 
     if version == 1:
-        chars = special_chars_v1
+        chars = _special_chars_v1_set
     elif version == 2:
-        chars = special_chars_v2
+        chars = _special_chars_v2_set
     else:
         raise ValueError("Invalid version. Must be 1 or 2.")
 

--- a/pytdbot/utils/json_utils.py
+++ b/pytdbot/utils/json_utils.py
@@ -45,14 +45,14 @@ empty_callback_data = CallbackData("")
 def load_callback_data(data: bytes) -> CallbackData:
     r"""loads already created callback data by :func:`~pytdbot.utils.callback_data`. Returns empty CallbackData on error"""
 
-    if not (data[0] == 0x5B and data[-1] == 0x5D):
+    if not data or not (data[0] == 0x5B and data[-1] == 0x5D):
         return empty_callback_data
 
     try:
         d = json_loads(data)
         if not isinstance(d, list) or len(d) != 2:
             return empty_callback_data
-    except Exception:
+    except (ValueError, TypeError):
         return empty_callback_data
     else:
         return CallbackData(*d)

--- a/pytdbot/utils/obj_encoder.py
+++ b/pytdbot/utils/obj_encoder.py
@@ -3,6 +3,8 @@ from base64 import b64encode
 
 from .. import types, utils
 
+_type_cache = {}
+
 
 def obj_to_json(obj, **kwargs):
     return json.dumps(obj_to_dict(obj), **kwargs)
@@ -24,7 +26,13 @@ def obj_to_dict(obj):
 def dict_to_obj(dict_obj, client=None):
     if isinstance(dict_obj, dict):
         if "@type" in dict_obj:
-            obj = getattr(types, utils.to_camel_case(dict_obj["@type"])).from_dict(
+            td_type = dict_obj["@type"]
+            obj_type = _type_cache.get(td_type)
+            if obj_type is None:
+                obj_type = getattr(types, utils.to_camel_case(td_type))
+                _type_cache[td_type] = obj_type
+
+            obj = obj_type.from_dict(
                 {key: dict_to_obj(value, client) for key, value in dict_obj.items()}
             )
             if client:

--- a/pytdbot/utils/strings.py
+++ b/pytdbot/utils/strings.py
@@ -48,5 +48,5 @@ def get_retry_after_time(error_message: str) -> int:
 
     try:
         return int(error_message.removeprefix(RETRY_AFTER_PREFEX))
-    except Exception:
+    except (ValueError, AttributeError):
         return 0

--- a/pytdbot/utils/strings.py
+++ b/pytdbot/utils/strings.py
@@ -9,20 +9,20 @@ def to_camel_case(input_str: str, delimiter: str = ".", is_class: bool = True) -
         return ""
 
     parts = input_str.split(delimiter)
-    camel_case_str = ""
 
-    for i, part in enumerate(parts):
-        if i > 0:
-            camel_case_str += part[0].upper() + part[1:]
-        else:
-            camel_case_str += part
+    result = [parts[0]]
+    for part in parts[1:]:
+        result.append(part[0].upper())
+        result.append(part[1:])
 
-    if camel_case_str:
-        camel_case_str = (
-            camel_case_str[0].upper() if is_class else camel_case_str[0].lower()
-        ) + camel_case_str[1:]
+    joined = "".join(result)
 
-    return camel_case_str
+    if not joined:
+        return ""
+
+    if is_class:
+        return joined[0].upper() + joined[1:]
+    return joined[0].lower() + joined[1:]
 
 
 def create_extra_id(bytes_size: int = 9):


### PR DESCRIPTION
## Summary
- await option send operations in `_set_options`
- use gather to keep option setup concurrent while observed
- builds on queue worker hardening

## Validation
- branch tip verified with `git verify-commit`
