### PR TITLE
Fix FormattedText parameter in sendCopy function

### DIFF
--- a/pytdbot/methods/methods.py
+++ b/pytdbot/methods/methods.py
@@ -1523,7 +1523,7 @@ class Methods(TDLibFunctions):
                 return parse
             caption = parse
         else:
-            caption = FormattedText(id=new_caption)
+            caption = FormattedText(text=new_caption)
 
         return await self.sendMessageWithContent(
             chat_id=chat_id,


### PR DESCRIPTION
This pull request makes a small fix to the `sendCopy` method in `pytdbot/methods/methods.py`, ensuring that the `FormattedText` object is initialized with the correct keyword argument.

* Changed the `FormattedText` constructor to use the `text` argument instead of the incorrect `id` argument when setting the caption.