### PR TITLE
Fix parameter names in function calls

### DIFF
--- a/pytdbot/types/bound_methods/callback_query.py
+++ b/pytdbot/types/bound_methods/callback_query.py
@@ -111,7 +111,7 @@ class CallbackQueryBoundMethods:
                 return parse
             caption = parse
         else:
-            caption = pytdbot.types.FormattedText(caption)
+            caption = pytdbot.types.FormattedText(text=caption)
 
         return await self._client.editMessageCaption(
             chat_id=self.chat_id,

--- a/pytdbot/utils/rich_converter.py
+++ b/pytdbot/utils/rich_converter.py
@@ -257,7 +257,7 @@ def _rt_math(rt, _):
 
 
 def _rt_mention_name(rt, f):
-    return mention(rt.user_id, _rt(rt.text, f), html=True, escape=False)
+    return mention(_rt(rt.text, f), rt.user_id, html=True, escape=False)
 
 
 def _rt_texts(rt, f):


### PR DESCRIPTION
This pull request introduces minor but important fixes to parameter usage in two functions, improving correctness and compatibility with expected function signatures.

Parameter fixes:

* In `pytdbot/types/bound_methods/callback_query.py`, the initialization of `FormattedText` now explicitly uses the `text` keyword argument, ensuring compatibility with the class constructor.
* In `pytdbot/utils/rich_converter.py`, the argument order for the `mention` function is corrected by passing the mention text before the user ID, matching the expected parameter order.